### PR TITLE
🥝그룹 코드로 이동해야하는 버튼(참여하기)에 대해 주석 설명 추가

### DIFF
--- a/lib/src/ui/join_make_page.dart
+++ b/lib/src/ui/join_make_page.dart
@@ -154,6 +154,7 @@ class _JoinMakePageState extends State<JoinMakePage> {
                                 Navigator.push(
                                     context,
                                     MaterialPageRoute(
+                                      //!!!이 아래 LoginPage()가 아니라 그룹 코드 작성하는 페이지로 이동해야함!!!
                                         builder: (context) => LoginPage()));
                               },
                               child: Text(


### PR DESCRIPTION
이후 백앤드에서 그룹코드 관련 페이지 가져오면 연동하기 