### PR TITLE
🍔임시 보관함, 임시 글 작성, 만들기 버튼에 이동 구현 

### DIFF
--- a/android/local.properties
+++ b/android/local.properties
@@ -1,5 +1,5 @@
-sdk.dir=/Users/anjeonghyeon/Library/Android/sdk
-flutter.sdk=/opt/homebrew/Caskroom/flutter/3.7.6/flutter
+sdk.dir=/Users/yeonhyeeun/Library/Android/sdk
+flutter.sdk=/Users/yeonhyeeun/flutter
 flutter.buildMode=debug
 flutter.versionName=1.0.0
 flutter.versionCode=1

--- a/lib/src/ui/Group/group_make.dart
+++ b/lib/src/ui/Group/group_make.dart
@@ -2,7 +2,10 @@ import 'package:dotted_border/dotted_border.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:get/get.dart';
+import 'package:get/get_core/src/get_main.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:mobalworld/src/ui/Setting/toung.dart';
 
 class GroupMake extends StatefulWidget {
   const GroupMake({Key? key}) : super(key: key);
@@ -190,7 +193,7 @@ class _GroupMakeState extends State<GroupMake> {
                 Padding(
                   padding: EdgeInsets.symmetric(horizontal: 0.02.sh,vertical: 0.01.sh),
                   child: ElevatedButton(onPressed: () {
-
+                    Get.to(ToungPage());
                   },
                     child: Text('만들기',style: GoogleFonts.notoSans
                       (textStyle: TextStyle(color: Colors.black),)

--- a/lib/src/ui/appbar page/temporary_storage.dart
+++ b/lib/src/ui/appbar page/temporary_storage.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 import '../bottom.dart';
+import '../temporary_write.dart';
 
 class Temporay_StoragePage extends StatefulWidget {
   const Temporay_StoragePage({super.key});
@@ -65,6 +66,11 @@ class _Temporay_StoragePageState extends State<Temporay_StoragePage> {
 
               // 임시 작성글 1
               ListTile(
+                onTap: () {
+                  Navigator.push(
+                      context,
+                      MaterialPageRoute(builder: (context) => TemporaryWrite()),);
+                },
                 dense: false,
                 // 사용자가 작성한 고민 글 제목 으로 보여주기
                 title: Text("쓰다만 글이지롱",

--- a/lib/src/ui/storagebox_btn.dart
+++ b/lib/src/ui/storagebox_btn.dart
@@ -1,7 +1,11 @@
+import 'dart:js';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:mobalworld/src/ui/Group/group_select.dart';
 
+import 'appbar page/storage.dart';
 import 'bottom.dart';
 import 'master_key.dart';
 
@@ -22,36 +26,38 @@ class _StorageboxState extends State<Storagebox> {
   Widget getButton({
     required String hint,
   }) {
-    return Container(
-      width: double.infinity,
-      // 버튼 높이
-      height: Getheight(0.02.sh),
-      child: ElevatedButton(
-        onPressed: () {},
-        style: ButtonStyle(
-          backgroundColor: MaterialStateProperty.all(beige),
-          foregroundColor: MaterialStateProperty.all(Colors.black),
-          padding: //패딩
-              MaterialStateProperty.all(EdgeInsets.symmetric(vertical: 14.h)),
-          textStyle: MaterialStateProperty.all(TextStyle(
-            fontSize: FontSize(15.sp),
-            fontWeight: FontWeight.w700,
-          )),
-          side: MaterialStateProperty.all(BorderSide(
-            width: 1.0, // 테두리의 두께를 조정하세요
-            color: beige, // 테두리의 색상을 원하는 색상으로 변경하세요
-          )),
-          shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-            RoundedRectangleBorder(
-              borderRadius:
-                  BorderRadius.circular(100.0), // 원하는 모서리의 둥근 정도를 조정하세요
+          return Container(
+            width: double.infinity,
+            // 버튼 높이
+            height: Getheight(0.02.sh),
+            child: ElevatedButton(
+              onPressed: () {
+              },
+              style: ButtonStyle(
+                backgroundColor: MaterialStateProperty.all(beige),
+                foregroundColor: MaterialStateProperty.all(Colors.black),
+                padding: //패딩
+                    MaterialStateProperty.all(EdgeInsets.symmetric(vertical: 14.h)),
+                textStyle: MaterialStateProperty.all(TextStyle(
+                  fontSize: FontSize(15.sp),
+                  fontWeight: FontWeight.w700,
+                )),
+                side: MaterialStateProperty.all(BorderSide(
+                  width: 1.0, // 테두리의 두께를 조정하세요
+                  color: beige, // 테두리의 색상을 원하는 색상으로 변경하세요
+                )),
+                shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+                  RoundedRectangleBorder(
+                    borderRadius:
+                        BorderRadius.circular(100.0), // 원하는 모서리의 둥근 정도를 조정하세요
+                  ),
+                ),
+              ),
+              child: Text(hint),
             ),
-          ),
-        ),
-        child: Text(hint),
-      ),
-    );
+          );
   }
+
 
   //버튼의 임계값
   double Getheight(double size) {
@@ -92,7 +98,7 @@ class _StorageboxState extends State<Storagebox> {
             children: [
               CircleAvatar(
                 backgroundColor: Colors.white,
-                backgroundImage: AssetImage('assets/walrus.png'),
+                backgroundImage: AssetImage('assets/images/walrus.png'),
                 radius: 40,
               ),
               SizedBox(
@@ -109,14 +115,23 @@ class _StorageboxState extends State<Storagebox> {
                 // 바다 코끼리와 위로 보관함 사이 여백 박스
                 height: 0.1.sh,
               ),
-              getButton(hint: "위로 보관함"),
+              getButton(hint: "위로 보관함"
+              ),
+
+
+
               SizedBox(
                 height: 0.03.sh,
               ),
+
               getButton(hint: "나의 고민 보관함"),
               SizedBox(
                 height: 0.03.sh,
               ),
+
+
+
+
               getButton(hint: "임시 보관함"),
               MasterKey(margin: 50)
             ],

--- a/lib/src/ui/temporary_write.dart
+++ b/lib/src/ui/temporary_write.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:get/get.dart';
+import 'package:get/get_core/src/get_main.dart';
+import 'package:mobalworld/src/ui/worry_Writing.dart';
+
+import 'Group/group_select.dart';
+import 'bottom.dart';
+
+class TemporaryWrite extends StatefulWidget {
+  const TemporaryWrite({super.key});
+
+  @override
+  State<TemporaryWrite> createState() => _TemporaryWriteState();
+}
+
+class _TemporaryWriteState extends State<TemporaryWrite> {
+  String title = '';
+  String content = '';
+  String group = "23-1 한동위로팀";
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: PreferredSize(
+        preferredSize: Size.fromHeight(75.0),
+        child: AppBar(
+          toolbarHeight: 75,
+          backgroundColor: Colors.white,
+          leading: TextButton(
+            child: Text(
+              '취소',
+              style: TextStyle(color: Colors.black, fontSize: 14.sp),
+            ),
+            onPressed: () {
+              showModalBottomSheet(
+                context: context,
+                builder: (BuildContext context) {
+                  return Container(
+                    color: Colors.white,
+                    height: 0.3.sh,
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        SizedBox(
+                          width: double.infinity,
+                          height: 0.1.sh,
+                          child: ElevatedButton(
+                            style: ButtonStyle(
+                              backgroundColor:
+                              MaterialStateProperty.all(Colors.white),
+                              elevation: MaterialStateProperty.all<double>(0),
+                            ),
+                            onPressed: () {
+                              Get.to(GroupSelect());
+                            },
+                            child: Text(
+                              '작성취소',
+                              style: TextStyle(color: Colors.red),
+                            ),
+                          ),
+                        ),
+                        SizedBox(
+                          height: 0.1.sh,
+                          width: double.infinity,
+                          child: ElevatedButton(
+                            style: ButtonStyle(
+                              backgroundColor:
+                              MaterialStateProperty.all(Colors.white),
+                              elevation: MaterialStateProperty.all<double>(0),
+                            ),
+                            onPressed: () {
+                              // Get.to(Setting());
+                            },
+                            child: Text(
+                              '임시저장',
+                              style: TextStyle(color: Colors.blue[300]),
+                            ),
+                          ),
+                        ),
+                        SizedBox(
+                          height: 0.1.sh,
+                          width: double.infinity,
+                          child: ElevatedButton(
+                            style: ButtonStyle(
+                              backgroundColor:
+                              MaterialStateProperty.all(Colors.white),
+                              elevation: MaterialStateProperty.all<double>(0),
+                            ),
+                            onPressed: () {
+                              Get.to(WorryWriting());
+                            },
+                            child: Text(
+                              '취소',
+                              style: TextStyle(
+                                  color: Colors.black, fontSize: 14.sp),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  );
+                },
+              );
+            },
+          ),
+          centerTitle: true,
+
+          title: Text(
+            group,
+            style: TextStyle(color: Colors.black, fontSize: 25),
+            textAlign: TextAlign.center,
+          ),
+          actions: [
+            TextButton(
+              child: Text(
+                '등록',
+                style: TextStyle(color: Colors.red[400], fontSize: 15.sp),
+              ),
+              onPressed: () {
+                Navigator.pop(context);
+              },
+
+            ),
+          ],
+        ),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: EdgeInsets.symmetric(horizontal: 0.03.sh, vertical: 0.02.sh),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              TextField(
+                decoration: InputDecoration(
+                  labelText: '제목',
+                ),
+                onChanged: (value) {
+                  setState(() {
+                    title = value;
+                  });
+                },
+              ),
+              SizedBox(height: 16.0),
+              TextField(
+                decoration: InputDecoration(
+                    labelText: '고민 내용', alignLabelWithHint: true),
+                onChanged: (value) {
+                  setState(() {
+                    content = value;
+                  });
+                },
+                maxLines: 10,
+              ),
+            ],
+          ),
+        ),
+      ),
+      bottomNavigationBar: bottomWidget(),
+    );
+  }
+}


### PR DESCRIPTION
🍔그룹 만들기 버튼 클릭시 일단 (해당 그룹의 메인 페이지로 이동해야함) 우선 작업완료된 글이 없으므로 텅 페이지로 이동으로 넣어놓음, 임시보관함에서 항목 하나 선택시 임시 작성하던 글 작성 페이지를 프론트만 구현, -> 백앤드에서 임시 작성중이던 글 제목으로 찾아서 불러와야함 